### PR TITLE
refactoring pImpl Design

### DIFF
--- a/12_Lighting_BlinnPhong/App.cpp
+++ b/12_Lighting_BlinnPhong/App.cpp
@@ -20,6 +20,51 @@
 #pragma comment (lib, "d3d11.lib")
 #pragma comment(lib,"d3dcompiler.lib")
 
+class PImplContainer::Impl
+{
+public:
+	Impl() : m_LineRenderer(nullptr), m_Skybox(nullptr){}
+
+	void InitLineRenderer(ID3D11Device* device)
+	{
+		m_LineRenderer = std::make_unique<LineRenderer>(device);
+	}
+
+	void InitSkyBox(ID3D11Device* device,
+		const wchar_t* skyboxPath,
+		ID3D11VertexShader* vs,
+		ID3D11PixelShader* ps,
+		ID3D11InputLayout* inputLayout,
+		ID3D11Buffer* constantBuffer)
+	{
+		m_Skybox = std::make_unique<Skybox>(device, skyboxPath, vs, ps, inputLayout, constantBuffer);
+	}
+
+	LineRenderer* GetLineRenderer() { return m_LineRenderer.get(); }
+	Skybox* GetSkybox() { return m_Skybox.get(); }
+
+	~Impl() = default;
+
+	std::unique_ptr<LineRenderer> m_LineRenderer;
+	std::unique_ptr<Skybox> m_Skybox;
+};
+
+PImplContainer::PImplContainer() : pImpl(std::make_unique<Impl>()) {}
+PImplContainer::~PImplContainer() = default;
+
+void PImplContainer::InitLineRenderer(ID3D11Device* device) { pImpl->InitLineRenderer(device); }
+void PImplContainer::InitSkyBox(ID3D11Device* device,
+	const wchar_t* skyboxPath,
+	ID3D11VertexShader* vs,
+	ID3D11PixelShader* ps,
+	ID3D11InputLayout* inputLayout,
+	ID3D11Buffer* constantBuffer) {
+	pImpl->InitSkyBox(device, skyboxPath, vs, ps, inputLayout, constantBuffer);
+}
+LineRenderer* PImplContainer::GetLineRenderer() { return pImpl->GetLineRenderer(); }
+Skybox* PImplContainer::GetSkybox() { return pImpl->GetSkybox(); }
+
+
 static bool LoadTextureSRVAndSize(ID3D11Device* device, const std::wstring& path,
 	ID3D11ShaderResourceView** outSRV, ImVec2* outSize)
 {
@@ -83,16 +128,16 @@ void App::PrepareSkyFaceSRVs()
 
 void App::ChangeSkyboxDDS(const wchar_t* ddsPath)
 {
-    if (m_Skybox)
-    {
-        if (m_Skybox->ChangeDDS(m_pDevice, ddsPath))
-        {
-            // also set for face view and PS binding
-            m_pTextureSRV = m_Skybox->GetTexture();
-            PrepareSkyFaceSRVs();
-            wcscpy_s(m_CurrentSkyboxPath, ddsPath);
-        }
-    }
+	if (Skybox* m_Skybox = pImpl.GetSkybox())
+	{
+		if (m_Skybox->ChangeDDS(m_pDevice, ddsPath))
+		{
+			// also set for face view and PS binding
+			m_pTextureSRV = m_Skybox->GetTexture();
+			PrepareSkyFaceSRVs();
+			wcscpy_s(m_CurrentSkyboxPath, ddsPath);
+		}
+	}
 }
 
 bool App::OnInitialize()
@@ -273,7 +318,7 @@ void App::OnRender()
 		m_pDeviceContext->VSSetConstantBuffers(0, 1, &m_pConstantBuffer);
 		m_pDeviceContext->PSSetConstantBuffers(0, 1, &m_pConstantBuffer);
 
-		UINT dbgStride = sizeof(VertexData);
+		UINT dbgStride = sizeof(VertexLightTex);
 		UINT dbgOffset = 0;
 		m_pDeviceContext->IASetPrimitiveTopology(D3D11_PRIMITIVE_TOPOLOGY_TRIANGLELIST);
 		m_pDeviceContext->IASetVertexBuffers(0, 1, &m_pDebugBoxVB, &dbgStride, &dbgOffset);
@@ -297,9 +342,11 @@ void App::OnRender()
 		m_pDeviceContext->PSSetConstantBuffers(0, 1, &m_pConstantBuffer);
 
 		// light direction (red)
-		m_LineRenderer->DrawLightDirection(m_pDeviceContext, m_LightPosition, m_DirLight.direction, 2.0f, m_pInputLayout, m_pVertexShader, m_pPixelShader, m_pConstantBuffer);
-		// symmetric axes centered at origin for better grid feel
-		m_LineRenderer->DrawAxesSymmetric(m_pDeviceContext, 100.0f, m_pInputLayout, m_pVertexShader, m_pPixelShader, m_pConstantBuffer);
+		if (LineRenderer* m_LineRenderer = pImpl.GetLineRenderer())
+		{
+			m_LineRenderer->DrawLightDirection(m_pDeviceContext, m_LightPosition, m_DirLight.direction, 2.0f, m_pInputLayout, m_pVertexShader, m_pPixelShader, m_pConstantBuffer);
+			m_LineRenderer->DrawAxesSymmetric(m_pDeviceContext, 100.0f, m_pInputLayout, m_pVertexShader, m_pPixelShader, m_pConstantBuffer);
+		}
 	}
 
 
@@ -307,7 +354,10 @@ void App::OnRender()
 	{
 		UINT stride = m_VertextBufferStride;
 		UINT offset = m_VertextBufferOffset;
-		m_Skybox->Render(m_pDeviceContext, m_pVertexBuffer, m_pIndexBuffer, m_nIndices, stride, offset, m_baseProjection.view, m_baseProjection.proj);
+		if (Skybox* m_Skybox = pImpl.GetSkybox())
+		{
+			m_Skybox->Render(m_pDeviceContext, m_pVertexBuffer, m_pIndexBuffer, m_nIndices, stride, offset, m_baseProjection.view, m_baseProjection.proj);
+		}
 	}
 
 	// 화면 오버레이 축(NDC)에 작게 표시
@@ -327,7 +377,8 @@ void App::OnRender()
 		m_pDeviceContext->PSSetConstantBuffers(0, 1, &m_pConstantBuffer);
 
 		// 좌상단 작은 축 표시
-		m_LineRenderer->DrawAxesOverlay(m_pDeviceContext, XMMatrixTranspose(m_baseProjection.view), DirectX::XMFLOAT2(-0.9f, 0.85f), 0.08f, m_pInputLayout, m_pVertexShader, m_pPixelShader, m_pConstantBuffer);
+		if (LineRenderer* m_LineRenderer = pImpl.GetLineRenderer())
+			m_LineRenderer->DrawAxesOverlay(m_pDeviceContext, XMMatrixTranspose(m_baseProjection.view), DirectX::XMFLOAT2(-0.9f, 0.85f), 0.08f, m_pInputLayout, m_pVertexShader, m_pPixelShader, m_pConstantBuffer);
 	}
 
 	// ImGui 프레임 및 UI 렌더링
@@ -595,16 +646,16 @@ bool App::InitScene()
 	ID3D10Blob* errorMessage = nullptr;	 // 에러 메시지를 저장할 버퍼.
 
 	// ***********************************************************************************************
-	// 큐브설정
-	// 24개 정점 (각 면 4개) + 텍스처 좌표
-	m_VertextBufferStride = sizeof(VertexData);
+    // 큐브설정 (VertexLightTex 레이아웃)
+    // 24개 정점 (각 면 4개) + 텍스처 좌표
+    m_VertextBufferStride = sizeof(VertexLightTex);
 	m_VertextBufferOffset = 0;
 	// ***********************************************************************************************
-	// 작은 큐브 데이터 설정
-	// 정점 넣는 것과 인덱스 버퍼 값을 넣는것은 CreateBox 함수 안에 있습니다
-	StaticMeshData cubeData = StaticMesh::CreateBox(XMFLOAT4(1, 1, 1, 1));
-	StaticMesh::AssignMemory(m_pDevice, m_pVertexBuffer, cubeData);
-	StaticMesh::AssignIndexMemory(m_pDevice, m_pIndexBuffer, cubeData, m_nIndices);
+    // 작은 큐브 데이터 설정 (LightTex)
+    // 정점 넣는 것과 인덱스 버퍼 값을 넣는것은 CreateBoxLightTex 함수 안에 있습니다
+    StaticMeshDataLightTex cubeData = StaticMesh::CreateBoxLightTex(XMFLOAT4(1, 1, 1, 1));
+    StaticMesh::AssignMemoryLightTex(m_pDevice, m_pVertexBuffer, cubeData);
+    StaticMesh::AssignIndexMemoryLightTex(m_pDevice, m_pIndexBuffer, cubeData, m_nIndices);
 
 	// ***********************************************************************************************
 	// 상수 버퍼 설정
@@ -654,17 +705,12 @@ bool App::InitScene()
 
 	// ***********************************************************************************************
 	// 유틸 초기화: 라인 렌더러, 스카이박스, 디버그 박스
-	if (!m_LineRenderer) m_LineRenderer = new LineRenderer();
-	m_LineRenderer->Initialize(m_pDevice);
-
-	// Skybox: 기존 Hanako를 기본으로 초기화 (선호 DDS를 설정)
-	if (!m_Skybox) m_Skybox = new Skybox();
 	// Skybox는 이미 CreateDDSTextureFromFile로 SRV가 생성되어 있으므로, 여기선 현재 선택된 SRV를 사용하도록 Initialize는 경로 기반 대신 스킵할 수 있습니다.
-	// 간편화를 위해 cubemap.dds로 초기화
-	m_Skybox->Initialize(m_pDevice, m_CurrentSkyboxPath, m_pSkyBoxVertexShader, m_pSkyBoxPixelShader, m_pSkyBoxInputLayout, m_pConstantBuffer);
+	pImpl.InitLineRenderer(m_pDevice);
+	pImpl.InitSkyBox(m_pDevice, m_CurrentSkyboxPath, m_pSkyBoxVertexShader, m_pSkyBoxPixelShader, m_pSkyBoxInputLayout, m_pConstantBuffer);
 
 	// Debug box buffers for light position marker
-	StaticMesh::CreateDebugBoxBuffers(m_pDevice, XMFLOAT4(1,1,1,1), 0.2f, &m_pDebugBoxVB, &m_pDebugBoxIB, &m_DebugBoxIndexCount);
+	StaticMesh::CreateDebugBoxBuffersLightTex(m_pDevice, XMFLOAT4(1,1,1,1), 0.2f, &m_pDebugBoxVB, &m_pDebugBoxIB, &m_DebugBoxIndexCount);
 
 	return true;
 }
@@ -690,8 +736,6 @@ void App::UninitScene()
 
     SAFE_RELEASE(m_pDebugBoxVB);
     SAFE_RELEASE(m_pDebugBoxIB);
-    if (m_LineRenderer) { m_LineRenderer->Release(); delete m_LineRenderer; m_LineRenderer = nullptr; }
-    if (m_Skybox) { m_Skybox->Release(); delete m_Skybox; m_Skybox = nullptr; }
 }
 
 bool App::InitTexture()

--- a/12_Lighting_BlinnPhong/App.h
+++ b/12_Lighting_BlinnPhong/App.h
@@ -16,6 +16,30 @@
 
 using namespace DirectX::SimpleMath;
 
+class LineRenderer;
+class Skybox;
+
+class PImplContainer
+{
+public:
+	PImplContainer();
+	~PImplContainer();
+
+	void InitLineRenderer(ID3D11Device* device);
+	void InitSkyBox(ID3D11Device* device,
+		const wchar_t* skyboxPath,
+		ID3D11VertexShader* vs,
+		ID3D11PixelShader* ps,
+		ID3D11InputLayout* inputLayout,
+		ID3D11Buffer* constantBuffer);
+
+	LineRenderer* GetLineRenderer();
+	Skybox* GetSkybox();
+private:
+	class Impl;
+	std::unique_ptr<Impl> pImpl;
+};
+
 // 방향 라이트
 struct DirectionalLight
 {
@@ -36,20 +60,9 @@ struct Material
 };
 
 
-class App :
-	public GameApp
+class App : public GameApp
 {
 public:
-
-	// 정점 레이아웃: POSITION/NORMAL/COLOR
-	struct LightVertex
-	{
-		DirectX::XMFLOAT3 pos;
-		DirectX::XMFLOAT3 normal;
-		DirectX::XMFLOAT4 color;
-		static const D3D11_INPUT_ELEMENT_DESC inputLayout[3];
-	};
-
 	// VS/PS 공용 상수버퍼(b0)
 	struct ConstantBuffer
 	{
@@ -77,7 +90,7 @@ public:
 	ID3D11PixelShader* m_pPixelShaderSolid = nullptr; 			// 픽셀 셰이더(마커용 흰색)
 
 	ID3D11SamplerState* m_pSamplerState = nullptr;
-	ID3D11BlendState* m_pAlphaBlendState = nullptr; 					// 알파 블렌딩 상태
+	ID3D11BlendState* m_pAlphaBlendState = nullptr; 			// 알파 블렌딩 상태
 	ID3D11VertexShader* m_pSkyBoxVertexShader = nullptr; 		// 스카이박스 정점 셰이더
 	ID3D11PixelShader* m_pSkyBoxPixelShader = nullptr; 			// 스카이박스 픽셀 셰이더(조명)	
 	ID3D11InputLayout* m_pSkyBoxInputLayout = nullptr; 			// 스카이박스 입력 레이아웃
@@ -101,9 +114,8 @@ public:
 	ConstantBuffer m_ConstantBuffer; 							// CPU-side 상수 버퍼 데이터
 	ID3D11Buffer* m_pLineVertexBuffer = nullptr; 				// 라이트 방향 표시용 라인 VB
 
-    // 분리된 유틸들
-    class LineRenderer* m_LineRenderer = nullptr;           // 선/좌표축 렌더러
-    class Skybox* m_Skybox = nullptr;                       // 스카이박스
+	PImplContainer pImpl;
+
     // 디버그 박스 버퍼
     ID3D11Buffer* m_pDebugBoxVB = nullptr;
     ID3D11Buffer* m_pDebugBoxIB = nullptr;

--- a/Common/LineRenderer.cpp
+++ b/Common/LineRenderer.cpp
@@ -5,6 +5,11 @@ using namespace DirectX;
 
 struct LineV { XMFLOAT3 pos; XMFLOAT3 normal; XMFLOAT4 color; };
 
+LineRenderer::LineRenderer(ID3D11Device* device)
+{
+	Initialize(device);
+}
+
 bool LineRenderer::Initialize(ID3D11Device* device)
 {
     if (m_vb) return true;

--- a/Common/LineRenderer.h
+++ b/Common/LineRenderer.h
@@ -7,6 +7,7 @@ class LineRenderer
 {
 public:
     LineRenderer() = default;
+    explicit LineRenderer(ID3D11Device* device);
     ~LineRenderer() { Release(); }
 
     bool Initialize(ID3D11Device* device);

--- a/Common/Skybox.cpp
+++ b/Common/Skybox.cpp
@@ -4,6 +4,15 @@
 
 using namespace DirectX;
 
+Skybox::Skybox(ID3D11Device* device, const wchar_t* ddsPath, ID3D11VertexShader* vs, ID3D11PixelShader* ps, ID3D11InputLayout* inputLayout, ID3D11Buffer* sharedConstantBuffer)
+{
+	Initialize(device, ddsPath, vs, ps, inputLayout, sharedConstantBuffer);
+}
+
+Skybox::~Skybox()
+{
+}
+
 bool Skybox::Initialize(ID3D11Device* device,
                         const wchar_t* ddsPath,
                         ID3D11VertexShader* vs,

--- a/Common/Skybox.h
+++ b/Common/Skybox.h
@@ -6,6 +6,14 @@
 class Skybox
 {
 public:
+    Skybox() = default;
+    Skybox(ID3D11Device* device,
+        const wchar_t* ddsPath,
+        ID3D11VertexShader* vs,
+        ID3D11PixelShader* ps,
+        ID3D11InputLayout* inputLayout,
+        ID3D11Buffer* sharedConstantBuffer);
+    ~Skybox();
     bool Initialize(ID3D11Device* device,
                     const wchar_t* ddsPath,
                     ID3D11VertexShader* vs,

--- a/Common/StaticMesh.cpp
+++ b/Common/StaticMesh.cpp
@@ -4,7 +4,7 @@
 #include "Helper.h"
 #include <d3d11.h>
 
-// 박스를 만드는 코드
+// 박스를 만드는 코드 (TBN)
 StaticMeshData StaticMesh::CreateBox(const XMFLOAT4& color, float width, float height, float depth)
 {
 	using namespace DirectX;
@@ -18,64 +18,41 @@ StaticMeshData StaticMesh::CreateBox(const XMFLOAT4& color, float width, float h
 	const float h2 = height * 0.5f;
 	const float d2 = depth * 0.5f;
 
-	/*
-	* @brief  정점(Vertex) 배열을 GPU 버퍼로 생성
-	* @details
-	*   - ByteWidth : 정점 전체 크기(정점 크기 × 개수)
-	*   - BindFlags : D3D11_BIND_VERTEX_BUFFER
-	*   - Usage     : DEFAULT (일반적 용도)
-	*   - 초기 데이터 : vbData.pSysMem = vertices
-	*   - Stride/Offset : IASetVertexBuffers용 파라미터
-	*   - 주의 : VertexInfo(color=Vec3), 셰이더/InputLayout의 COLOR 형식 일치 필요
-	*/
+	// Front (-Z)
+	staticMeshData.vertices.push_back(VertexTBN{ XMFLOAT3(-w2, -h2, -d2), XMFLOAT3(0, 0, -1), XMFLOAT3(1, 0, 0), XMFLOAT3(0, -1, 0), color, XMFLOAT2(0, 1) });
+	staticMeshData.vertices.push_back(VertexTBN{ XMFLOAT3(-w2,  h2, -d2), XMFLOAT3(0, 0, -1), XMFLOAT3(1, 0, 0), XMFLOAT3(0, -1, 0), color, XMFLOAT2(0, 0) });
+	staticMeshData.vertices.push_back(VertexTBN{ XMFLOAT3(w2,  h2, -d2), XMFLOAT3(0, 0, -1), XMFLOAT3(1, 0, 0), XMFLOAT3(0, -1, 0), color, XMFLOAT2(1, 0) });
+	staticMeshData.vertices.push_back(VertexTBN{ XMFLOAT3(w2, -h2, -d2), XMFLOAT3(0, 0, -1), XMFLOAT3(1, 0, 0), XMFLOAT3(0, -1, 0), color, XMFLOAT2(1, 1) });
 
-	// 정점 24개 Front, Left, Top, Back, Right, Bottom (6면 * 4점씩)
-	// Front (N = (0,0,-1))
-	staticMeshData.vertices.push_back({ XMFLOAT3(-w2,-h2,-d2), XMFLOAT3(0, 0,-1), color, XMFLOAT2(0.0f, 1.0f) });
-	staticMeshData.vertices.push_back({ XMFLOAT3(-w2, h2,-d2), XMFLOAT3(0, 0,-1), color, XMFLOAT2(0.0f, 0.0f) });
-	staticMeshData.vertices.push_back({ XMFLOAT3(w2, h2,-d2),  XMFLOAT3(0, 0,-1), color, XMFLOAT2(1.0f, 0.0f) });
-	staticMeshData.vertices.push_back({ XMFLOAT3(w2,-h2,-d2),  XMFLOAT3(0, 0,-1), color, XMFLOAT2(1.0f, 1.0f) });
+	// Left (-X)
+	staticMeshData.vertices.push_back(VertexTBN{ XMFLOAT3(-w2, -h2,  d2), XMFLOAT3(-1, 0, 0), XMFLOAT3(0, 0, -1), XMFLOAT3(0, 1, 0), color, XMFLOAT2(0, 1) });
+	staticMeshData.vertices.push_back(VertexTBN{ XMFLOAT3(-w2,  h2,  d2), XMFLOAT3(-1, 0, 0), XMFLOAT3(0, 0, -1), XMFLOAT3(0, 1, 0), color, XMFLOAT2(0, 0) });
+	staticMeshData.vertices.push_back(VertexTBN{ XMFLOAT3(-w2,  h2, -d2), XMFLOAT3(-1, 0, 0), XMFLOAT3(0, 0, -1), XMFLOAT3(0, 1, 0), color, XMFLOAT2(1, 0) });
+	staticMeshData.vertices.push_back(VertexTBN{ XMFLOAT3(-w2, -h2, -d2), XMFLOAT3(-1, 0, 0), XMFLOAT3(0, 0, -1), XMFLOAT3(0, 1, 0), color, XMFLOAT2(1, 1) });
 
-	// Left (x = -w2), N = (-1,0,0)
-	staticMeshData.vertices.push_back({ XMFLOAT3(-w2,-h2, d2), XMFLOAT3(-1, 0, 0), color, XMFLOAT2(0.0f, 1.0f) });
-	staticMeshData.vertices.push_back({ XMFLOAT3(-w2, h2, d2), XMFLOAT3(-1, 0, 0), color, XMFLOAT2(0.0f, 0.0f) });
-	staticMeshData.vertices.push_back({ XMFLOAT3(-w2, h2,-d2), XMFLOAT3(-1, 0, 0), color, XMFLOAT2(1.0f, 0.0f) });
-	staticMeshData.vertices.push_back({ XMFLOAT3(-w2,-h2,-d2), XMFLOAT3(-1, 0, 0), color, XMFLOAT2(1.0f, 1.0f) });
+	// Top (+Y)
+	staticMeshData.vertices.push_back(VertexTBN{ XMFLOAT3(-w2,  h2, -d2), XMFLOAT3(0, 1, 0), XMFLOAT3(1, 0, 0), XMFLOAT3(0, 0, 1), color, XMFLOAT2(0, 1) });
+	staticMeshData.vertices.push_back(VertexTBN{ XMFLOAT3(-w2,  h2,  d2), XMFLOAT3(0, 1, 0), XMFLOAT3(1, 0, 0), XMFLOAT3(0, 0, 1), color, XMFLOAT2(0, 0) });
+	staticMeshData.vertices.push_back(VertexTBN{ XMFLOAT3(w2,  h2,  d2), XMFLOAT3(0, 1, 0), XMFLOAT3(1, 0, 0), XMFLOAT3(0, 0, 1), color, XMFLOAT2(1, 0) });
+	staticMeshData.vertices.push_back(VertexTBN{ XMFLOAT3(w2,  h2, -d2), XMFLOAT3(0, 1, 0), XMFLOAT3(1, 0, 0), XMFLOAT3(0, 0, 1), color, XMFLOAT2(1, 1) });
 
-	// Top (y = +h2), N = (0,1,0)
-	staticMeshData.vertices.push_back({ XMFLOAT3(-w2, h2,-d2), XMFLOAT3(0, 1, 0), color, XMFLOAT2(0.0f, 1.0f) });
-	staticMeshData.vertices.push_back({ XMFLOAT3(-w2, h2, d2), XMFLOAT3(0, 1, 0), color, XMFLOAT2(0.0f, 0.0f) });
-	staticMeshData.vertices.push_back({ XMFLOAT3(w2, h2, d2),  XMFLOAT3(0, 1, 0), color, XMFLOAT2(1.0f, 0.0f) });
-	staticMeshData.vertices.push_back({ XMFLOAT3(w2, h2,-d2),  XMFLOAT3(0, 1, 0), color, XMFLOAT2(1.0f, 1.0f) });
+	// Back (+Z)
+	staticMeshData.vertices.push_back(VertexTBN{ XMFLOAT3(w2, -h2,  d2), XMFLOAT3(0, 0, 1), XMFLOAT3(-1, 0, 0), XMFLOAT3(0, 1, 0), color, XMFLOAT2(0, 1) });
+	staticMeshData.vertices.push_back(VertexTBN{ XMFLOAT3(w2,  h2,  d2), XMFLOAT3(0, 0, 1), XMFLOAT3(-1, 0, 0), XMFLOAT3(0, 1, 0), color, XMFLOAT2(0, 0) });
+	staticMeshData.vertices.push_back(VertexTBN{ XMFLOAT3(-w2,  h2,  d2), XMFLOAT3(0, 0, 1), XMFLOAT3(-1, 0, 0), XMFLOAT3(0, 1, 0), color, XMFLOAT2(1, 0) });
+	staticMeshData.vertices.push_back(VertexTBN{ XMFLOAT3(-w2, -h2,  d2), XMFLOAT3(0, 0, 1), XMFLOAT3(-1, 0, 0), XMFLOAT3(0, 1, 0), color, XMFLOAT2(1, 1) });
 
-	// Back (z = +d2), N = (0,0,1)
-	staticMeshData.vertices.push_back({ XMFLOAT3(w2,-h2, d2),  XMFLOAT3(0, 0, 1), color, XMFLOAT2(0.0f, 1.0f) });
-	staticMeshData.vertices.push_back({ XMFLOAT3(w2, h2, d2),  XMFLOAT3(0, 0, 1), color, XMFLOAT2(0.0f, 0.0f) });
-	staticMeshData.vertices.push_back({ XMFLOAT3(-w2, h2, d2), XMFLOAT3(0, 0, 1), color, XMFLOAT2(1.0f, 0.0f) });
-	staticMeshData.vertices.push_back({ XMFLOAT3(-w2,-h2, d2), XMFLOAT3(0, 0, 1), color, XMFLOAT2(1.0f, 1.0f) });
+	// Right (+X)
+	staticMeshData.vertices.push_back(VertexTBN{ XMFLOAT3(w2, -h2, -d2), XMFLOAT3(1, 0, 0), XMFLOAT3(0, 0, 1), XMFLOAT3(0, 1, 0), color, XMFLOAT2(0, 1) });
+	staticMeshData.vertices.push_back(VertexTBN{ XMFLOAT3(w2,  h2, -d2), XMFLOAT3(1, 0, 0), XMFLOAT3(0, 0, 1), XMFLOAT3(0, 1, 0), color, XMFLOAT2(0, 0) });
+	staticMeshData.vertices.push_back(VertexTBN{ XMFLOAT3(w2,  h2,  d2), XMFLOAT3(1, 0, 0), XMFLOAT3(0, 0, 1), XMFLOAT3(0, 1, 0), color, XMFLOAT2(1, 0) });
+	staticMeshData.vertices.push_back(VertexTBN{ XMFLOAT3(w2, -h2,  d2), XMFLOAT3(1, 0, 0), XMFLOAT3(0, 0, 1), XMFLOAT3(0, 1, 0), color, XMFLOAT2(1, 1) });
 
-	// Right (x = +w2), N = (1,0,0)
-	staticMeshData.vertices.push_back({ XMFLOAT3(w2,-h2,-d2), XMFLOAT3(1, 0, 0), color, XMFLOAT2(0.0f, 1.0f) });
-	staticMeshData.vertices.push_back({ XMFLOAT3(w2, h2,-d2),  XMFLOAT3(1, 0, 0), color, XMFLOAT2(0.0f, 0.0f) });
-	staticMeshData.vertices.push_back({ XMFLOAT3(w2, h2, d2),  XMFLOAT3(1, 0, 0), color, XMFLOAT2(1.0f, 0.0f) });
-	staticMeshData.vertices.push_back({ XMFLOAT3(w2,-h2, d2),  XMFLOAT3(1, 0, 0), color, XMFLOAT2(1.0f, 1.0f) });
-
-	// Bottom (y = -h2), N = (0,-1,0)
-	staticMeshData.vertices.push_back({ XMFLOAT3(-w2,-h2, d2), XMFLOAT3(0,-1, 0), color, XMFLOAT2(0.0f, 1.0f) });
-	staticMeshData.vertices.push_back({ XMFLOAT3(-w2,-h2,-d2), XMFLOAT3(0,-1, 0), color, XMFLOAT2(0.0f, 0.0f) });
-	staticMeshData.vertices.push_back({ XMFLOAT3(w2,-h2,-d2),  XMFLOAT3(0,-1, 0), color, XMFLOAT2(1.0f, 0.0f) });
-	staticMeshData.vertices.push_back({ XMFLOAT3(w2,-h2, d2),  XMFLOAT3(0,-1, 0), color, XMFLOAT2(1.0f, 1.0f) });
-
-	/*
-	* @brief  인덱스 버퍼(Index Buffer) 생성
-	* @details
-	*   - indices: 정점 재사용용 (사각형 = 삼각형 2개 = 인덱스 6개)
-	*   - WORD 타입 → DXGI_FORMAT_R16_UINT 사용 예정
-	*   - ByteWidth : 전체 인덱스 배열 크기
-	*   - BindFlags : D3D11_BIND_INDEX_BUFFER
-	*   - Usage     : DEFAULT (GPU 일반 접근)
-	*   - 이 코드의 결과: m_pIndexBuffer 생성, m_nIndices에 개수 저장
-	*/
+	// Bottom (-Y)
+	staticMeshData.vertices.push_back(VertexTBN{ XMFLOAT3(-w2, -h2,  d2), XMFLOAT3(0, -1, 0), XMFLOAT3(1, 0, 0), XMFLOAT3(0, 0, -1), color, XMFLOAT2(0, 1) });
+	staticMeshData.vertices.push_back(VertexTBN{ XMFLOAT3(-w2, -h2, -d2), XMFLOAT3(0, -1, 0), XMFLOAT3(1, 0, 0), XMFLOAT3(0, 0, -1), color, XMFLOAT2(0, 0) });
+	staticMeshData.vertices.push_back(VertexTBN{ XMFLOAT3(w2, -h2, -d2), XMFLOAT3(0, -1, 0), XMFLOAT3(1, 0, 0), XMFLOAT3(0, 0, -1), color, XMFLOAT2(1, 0) });
+	staticMeshData.vertices.push_back(VertexTBN{ XMFLOAT3(w2, -h2,  d2), XMFLOAT3(0, -1, 0), XMFLOAT3(1, 0, 0), XMFLOAT3(0, 0, -1), color, XMFLOAT2(1, 1) });
 
 	staticMeshData.indices = {
 		0, 1, 2, 2, 3, 0,		// 오른쪽 (+X 쪽)
@@ -92,14 +69,14 @@ StaticMeshData StaticMesh::CreateBox(const XMFLOAT4& color, float width, float h
 void StaticMesh::AssignMemory(ID3D11Device*& m_pDevice, ID3D11Buffer*& m_pVertexBuffer, StaticMeshData& meshData)
 {
 	D3D11_BUFFER_DESC vbDesc = {};
-	ZeroMemory(&vbDesc, sizeof(vbDesc));											// vbDesc에 0으로 전체 메모리 영역을 초기화 시킵니다
-	vbDesc.ByteWidth = sizeof(VertexData) * meshData.vertices.size();				// 배열 전체의 바이트 크기를 바로 반환합니다
+	ZeroMemory(&vbDesc, sizeof(vbDesc));												// vbDesc에 0으로 전체 메모리 영역을 초기화 시킵니다
+	vbDesc.ByteWidth = (UINT)(sizeof(VertexTBN) * meshData.vertices.size());				// 배열 전체의 바이트 크기를 바로 반환합니다
 	vbDesc.BindFlags = D3D11_BIND_VERTEX_BUFFER;
 	vbDesc.Usage = D3D11_USAGE_DEFAULT;
 
 	D3D11_SUBRESOURCE_DATA vbData = {};
 	ZeroMemory(&vbData, sizeof(vbData));
-	vbData.pSysMem = meshData.vertices.data();										// 배열 데이터 할당.
+	vbData.pSysMem = meshData.vertices.data();												// 배열 데이터 할당.
 	HR_T(m_pDevice->CreateBuffer(&vbDesc, &vbData, &m_pVertexBuffer));
 }
 
@@ -107,12 +84,101 @@ void StaticMesh::AssignIndexMemory(ID3D11Device*& m_pDevice, ID3D11Buffer*& m_pI
 {
 	D3D11_BUFFER_DESC ibDesc = {};
 	ZeroMemory(&ibDesc, sizeof(ibDesc));
-	m_nIndices = meshData.indices.size();	// 인덱스 개수 저장.
-	ibDesc.ByteWidth = sizeof(DWORD) * meshData.indices.size();
+	m_nIndices = (int)meshData.indices.size();	// 인덱스 개수 저장.
+	ibDesc.ByteWidth = (UINT)(sizeof(DWORD) * meshData.indices.size());
 	ibDesc.BindFlags = D3D11_BIND_INDEX_BUFFER;
 	ibDesc.Usage = D3D11_USAGE_DEFAULT;
 
 	D3D11_SUBRESOURCE_DATA ibData = {};
 	ibData.pSysMem = meshData.indices.data();
 	HR_T(m_pDevice->CreateBuffer(&ibDesc, &ibData, &m_pIndexBuffer));
+}
+
+// ---------------- LightTex 버전 ----------------
+StaticMeshDataLightTex StaticMesh::CreateBoxLightTex(const XMFLOAT4& color, float width, float height, float depth)
+{
+	using namespace DirectX;
+	StaticMeshDataLightTex data;
+	data.vertices.reserve(24);
+	data.indices.reserve(36);
+
+	const float w2 = width * 0.5f;
+	const float h2 = height * 0.5f;
+	const float d2 = depth * 0.5f;
+
+	// Front (-Z)
+	data.vertices.push_back(VertexLightTex{ XMFLOAT3(-w2, -h2, -d2), XMFLOAT3(0, 0, -1), color, XMFLOAT2(0, 1) });
+	data.vertices.push_back(VertexLightTex{ XMFLOAT3(-w2,  h2, -d2), XMFLOAT3(0, 0, -1), color, XMFLOAT2(0, 0) });
+	data.vertices.push_back(VertexLightTex{ XMFLOAT3(w2,  h2, -d2), XMFLOAT3(0, 0, -1), color, XMFLOAT2(1, 0) });
+	data.vertices.push_back(VertexLightTex{ XMFLOAT3(w2, -h2, -d2), XMFLOAT3(0, 0, -1), color, XMFLOAT2(1, 1) });
+
+	// Left (-X)
+	data.vertices.push_back(VertexLightTex{ XMFLOAT3(-w2, -h2,  d2), XMFLOAT3(-1, 0, 0), color, XMFLOAT2(0, 1) });
+	data.vertices.push_back(VertexLightTex{ XMFLOAT3(-w2,  h2,  d2), XMFLOAT3(-1, 0, 0), color, XMFLOAT2(0, 0) });
+	data.vertices.push_back(VertexLightTex{ XMFLOAT3(-w2,  h2, -d2), XMFLOAT3(-1, 0, 0), color, XMFLOAT2(1, 0) });
+	data.vertices.push_back(VertexLightTex{ XMFLOAT3(-w2, -h2, -d2), XMFLOAT3(-1, 0, 0), color, XMFLOAT2(1, 1) });
+
+	// Top (+Y)
+	data.vertices.push_back(VertexLightTex{ XMFLOAT3(-w2, h2, -d2), XMFLOAT3(0, 1, 0), color, XMFLOAT2(0, 1) });
+	data.vertices.push_back(VertexLightTex{ XMFLOAT3(-w2, h2,  d2), XMFLOAT3(0, 1, 0), color, XMFLOAT2(0, 0) });
+	data.vertices.push_back(VertexLightTex{ XMFLOAT3(w2, h2,  d2), XMFLOAT3(0, 1, 0), color, XMFLOAT2(1, 0) });
+	data.vertices.push_back(VertexLightTex{ XMFLOAT3(w2, h2, -d2), XMFLOAT3(0, 1, 0), color, XMFLOAT2(1, 1) });
+
+	// Back (+Z)
+	data.vertices.push_back(VertexLightTex{ XMFLOAT3(w2, -h2,  d2), XMFLOAT3(0, 0, 1), color, XMFLOAT2(0, 1) });
+	data.vertices.push_back(VertexLightTex{ XMFLOAT3(w2,  h2,  d2), XMFLOAT3(0, 0, 1), color, XMFLOAT2(0, 0) });
+	data.vertices.push_back(VertexLightTex{ XMFLOAT3(-w2, h2,  d2), XMFLOAT3(0, 0, 1), color, XMFLOAT2(1, 0) });
+	data.vertices.push_back(VertexLightTex{ XMFLOAT3(-w2, -h2,  d2), XMFLOAT3(0, 0, 1), color, XMFLOAT2(1, 1) });
+
+	// Right (+X)
+	data.vertices.push_back(VertexLightTex{ XMFLOAT3(w2, -h2, -d2), XMFLOAT3(1, 0, 0), color, XMFLOAT2(0, 1) });
+	data.vertices.push_back(VertexLightTex{ XMFLOAT3(w2,  h2, -d2), XMFLOAT3(1, 0, 0), color, XMFLOAT2(0, 0) });
+	data.vertices.push_back(VertexLightTex{ XMFLOAT3(w2, h2,  d2), XMFLOAT3(1, 0, 0), color, XMFLOAT2(1, 0) });
+	data.vertices.push_back(VertexLightTex{ XMFLOAT3(w2, -h2,  d2), XMFLOAT3(1, 0, 0), color, XMFLOAT2(1, 1) });
+
+	// Bottom (-Y)
+	data.vertices.push_back(VertexLightTex{ XMFLOAT3(-w2, -h2,  d2), XMFLOAT3(0, -1, 0), color, XMFLOAT2(0, 1) });
+	data.vertices.push_back(VertexLightTex{ XMFLOAT3(-w2, -h2, -d2), XMFLOAT3(0, -1, 0), color, XMFLOAT2(0, 0) });
+	data.vertices.push_back(VertexLightTex{ XMFLOAT3(w2, -h2, -d2), XMFLOAT3(0, -1, 0), color, XMFLOAT2(1, 0) });
+	data.vertices.push_back(VertexLightTex{ XMFLOAT3(w2, -h2,  d2), XMFLOAT3(0, -1, 0), color, XMFLOAT2(1, 1) });
+
+	data.indices = {
+		0, 1, 2, 2, 3, 0,		// 오른쪽 (+X 쪽)
+		4, 5, 6, 6, 7, 4,		// 왼쪽 (X 쪽)
+		8, 9, 10, 10, 11, 8,	// 상부 표면 (+y 표면)
+		12, 13, 14, 14, 15, 12,	// 바닥 (Y 측면)
+		16, 17, 18, 18, 19, 16, // 뒤로 (+z 측)
+		20, 21, 22, 22, 23, 20	// 전면 (Z 측)
+	};
+
+	return data;
+}
+
+
+void StaticMesh::AssignMemoryLightTex(ID3D11Device*& device, ID3D11Buffer*& outVB, StaticMeshDataLightTex& meshData)
+{
+	D3D11_BUFFER_DESC vbDesc = {};
+	ZeroMemory(&vbDesc, sizeof(vbDesc));
+	vbDesc.ByteWidth = sizeof(VertexLightTex) * meshData.vertices.size();
+	vbDesc.BindFlags = D3D11_BIND_VERTEX_BUFFER;
+	vbDesc.Usage = D3D11_USAGE_DEFAULT;
+
+	D3D11_SUBRESOURCE_DATA vbData = {};
+	ZeroMemory(&vbData, sizeof(vbData));
+	vbData.pSysMem = meshData.vertices.data();
+	HR_T(device->CreateBuffer(&vbDesc, &vbData, &outVB));
+}
+
+void StaticMesh::AssignIndexMemoryLightTex(ID3D11Device*& device, ID3D11Buffer*& outIB, StaticMeshDataLightTex& meshData, int& outIndexCount)
+{
+	D3D11_BUFFER_DESC ibDesc = {};
+	ZeroMemory(&ibDesc, sizeof(ibDesc));
+	outIndexCount = meshData.indices.size();
+	ibDesc.ByteWidth = sizeof(DWORD) * meshData.indices.size();
+	ibDesc.BindFlags = D3D11_BIND_INDEX_BUFFER;
+	ibDesc.Usage = D3D11_USAGE_DEFAULT;
+
+	D3D11_SUBRESOURCE_DATA ibData = {};
+	ibData.pSysMem = meshData.indices.data();
+	HR_T(device->CreateBuffer(&ibDesc, &ibData, &outIB));
 }

--- a/Common/StaticMesh.h
+++ b/Common/StaticMesh.h
@@ -1,42 +1,57 @@
 #pragma once
 
 #include <d3d11.h>
+#include "Vertex.h"
 #include <directxtk/SimpleMath.h>
+    #include <vector>
 
-struct VertexData
-{
-	DirectX::XMFLOAT3 vertices;
-	DirectX::XMFLOAT3 normals;
-	DirectX::XMFLOAT4 colors;
-	DirectX::XMFLOAT2 texcoord;
-	static const D3D11_INPUT_ELEMENT_DESC inputLayout[3];
-};
-
+// TBN 정점
 struct StaticMeshData
 {
-	std::vector<VertexData> vertices;	// 24
-	std::vector<DWORD>    indices;   // 36
+	std::vector<VertexTBN> vertices; // 24
+	std::vector<DWORD>     indices;  // 36
+};
+
+// LightTex 정점
+struct StaticMeshDataLightTex
+{
+	std::vector<VertexLightTex> vertices; // 24
+	std::vector<DWORD>          indices;  // 36
 };
 
 class StaticMesh
 {
 public:
-	// 정적으로 박스를 만드는 코드입니다
-	static StaticMeshData CreateBox(const DirectX::XMFLOAT4& color,float width = 2, float height = 2, float depth = 2);
-	static void AssignMemory(ID3D11Device*& m_pDevice, ID3D11Buffer*& m_pVertexBuffer, StaticMeshData& meshData);
-	static void AssignIndexMemory(ID3D11Device*& m_pDevice, ID3D11Buffer*& m_pIndexBuffer, StaticMeshData& meshData, int& m_nIndices);
+	// 정적으로 TBN이 적용된 박스를 만듭니다 
+	static StaticMeshData CreateBox(const DirectX::XMFLOAT4& color, float width = 2, float height = 2, float depth = 2);
+	static void AssignMemory(ID3D11Device*& device, ID3D11Buffer*& outVB, StaticMeshData& meshData);
+	static void AssignIndexMemory(ID3D11Device*& device, ID3D11Buffer*& outIB, StaticMeshData& meshData, int& outIndexCount);
 
-    // 디버그용 작은 상자 생성/그리기
-    static StaticMeshData CreateDebugBox(const DirectX::XMFLOAT4& color, float size = 0.2f)
-    {
-        return CreateBox(color, size, size, size);
-    }
-    static void CreateDebugBoxBuffers(ID3D11Device* device, const DirectX::XMFLOAT4& color, float size,
-        ID3D11Buffer** outVB, ID3D11Buffer** outIB, int* outIndexCount)
-    {
-        StaticMeshData data = CreateDebugBox(color, size);
-        AssignMemory(const_cast<ID3D11Device*&>(device), *outVB, data);
-        AssignIndexMemory(const_cast<ID3D11Device*&>(device), *outIB, data, *outIndexCount);
-    }
+	// 정적으로 TBN이 적용되지 않은 박스를 만듭니다. LightTex
+    static StaticMeshDataLightTex CreateBoxLightTex(const DirectX::XMFLOAT4& color, float width = 2, float height = 2, float depth = 2);
+	static void AssignMemoryLightTex(ID3D11Device*& device, ID3D11Buffer*& outVB, StaticMeshDataLightTex& meshData);
+	static void AssignIndexMemoryLightTex(ID3D11Device*& device, ID3D11Buffer*& outIB, StaticMeshDataLightTex& meshData, int& outIndexCount);
+
+	// 디버그 박스
+	static StaticMeshData CreateDebugBox(const DirectX::XMFLOAT4& color, float size = 0.2f)
+	{
+		return CreateBox(color, size, size, size);
+	}
+	static void CreateDebugBoxBuffers(ID3D11Device* device, const DirectX::XMFLOAT4& color, float size,
+		ID3D11Buffer** outVB, ID3D11Buffer** outIB, int* outIndexCount)
+	{
+		StaticMeshData data = CreateDebugBox(color, size);
+		AssignMemory(const_cast<ID3D11Device*&>(device), *outVB, data);
+		AssignIndexMemory(const_cast<ID3D11Device*&>(device), *outIB, data, *outIndexCount);
+	}
+
+	// 디버그 박스(LightTex)
+	static void CreateDebugBoxBuffersLightTex(ID3D11Device* device, const DirectX::XMFLOAT4& color, float size,
+		ID3D11Buffer** outVB, ID3D11Buffer** outIB, int* outIndexCount)
+	{
+		StaticMeshDataLightTex data = CreateBoxLightTex(color, size, size, size);
+		AssignMemoryLightTex(const_cast<ID3D11Device*&>(device), *outVB, data);
+		AssignIndexMemoryLightTex(const_cast<ID3D11Device*&>(device), *outIB, data, *outIndexCount);
+	}
 };
 


### PR DESCRIPTION
헤더파일에서 include로 추가하던 종속성을 제거하고 cpp에서만 추가가 가능함

```
class LineRenderer;
class Skybox;

class PImplContainer
{
public:
	PImplContainer();
	~PImplContainer();

	void InitLineRenderer(ID3D11Device* device);
	void InitSkyBox(ID3D11Device* device,
		const wchar_t* skyboxPath,
		ID3D11VertexShader* vs,
		ID3D11PixelShader* ps,
		ID3D11InputLayout* inputLayout,
		ID3D11Buffer* constantBuffer);

	LineRenderer* GetLineRenderer();
	Skybox* GetSkybox();
private:
	class Impl;
	std::unique_ptr<Impl> pImpl;
};

```



```
class PImplContainer::Impl
{
public:
	Impl() : m_LineRenderer(nullptr), m_Skybox(nullptr){}

	void InitLineRenderer(ID3D11Device* device)
	{
		m_LineRenderer = std::make_unique<LineRenderer>(device);
	}

	void InitSkyBox(ID3D11Device* device,
		const wchar_t* skyboxPath,
		ID3D11VertexShader* vs,
		ID3D11PixelShader* ps,
		ID3D11InputLayout* inputLayout,
		ID3D11Buffer* constantBuffer)
	{
		m_Skybox = std::make_unique<Skybox>(device, skyboxPath, vs, ps, inputLayout, constantBuffer);
	}

	LineRenderer* GetLineRenderer() { return m_LineRenderer.get(); }
	Skybox* GetSkybox() { return m_Skybox.get(); }

	~Impl() = default;

	std::unique_ptr<LineRenderer> m_LineRenderer;
	std::unique_ptr<Skybox> m_Skybox;
};

PImplContainer::PImplContainer() : pImpl(std::make_unique<Impl>()) {}
PImplContainer::~PImplContainer() = default;

void PImplContainer::InitLineRenderer(ID3D11Device* device) { pImpl->InitLineRenderer(device); }
void PImplContainer::InitSkyBox(ID3D11Device* device,
	const wchar_t* skyboxPath,
	ID3D11VertexShader* vs,
	ID3D11PixelShader* ps,
	ID3D11InputLayout* inputLayout,
	ID3D11Buffer* constantBuffer) {
	pImpl->InitSkyBox(device, skyboxPath, vs, ps, inputLayout, constantBuffer);
}
LineRenderer* PImplContainer::GetLineRenderer() { return pImpl->GetLineRenderer(); }
Skybox* PImplContainer::GetSkybox() { return pImpl->GetSkybox(); }

```